### PR TITLE
Return a Promise from fontkit.open if no callback is provided

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,18 @@ var fontkit = require('fontkit')
 // open a font synchronously
 var font = fontkit.openSync('font.ttf')
 
+// or, open a font asynchronously, providing a callback
+fontkit.open('font.ttf', (err, font) => {
+  // use font or handle error
+})
+
+// or, open a font asynchronously, awaiting a Promise
+fontkit.open('font.ttf').then(font => {
+  // use font
+}).catch(err => {
+  // handle error
+})
+
 // layout a string, using default shaping features.
 // returns a GlyphRun, describing glyphs and positions.
 var run = font.layout('hello world!')

--- a/src/base.js
+++ b/src/base.js
@@ -29,19 +29,25 @@ fontkit.open = function(filename, postscriptName, callback) {
     postscriptName = null;
   }
 
-  fs.readFile(filename, function(err, buffer) {
-    if (err) { return callback(err); }
+  const openingPromise = new Promise((resolve, reject) => {
+    fs.readFile(filename, (err, buffer) => {
+      if (err) { return reject(err); }
 
-    try {
-      var font = fontkit.create(buffer, postscriptName);
-    } catch (e) {
-      return callback(e);
-    }
+      try {
+        var font = fontkit.create(buffer, postscriptName);
+      } catch (err) {
+        return reject(err);
+      }
 
-    return callback(null, font);
+      return resolve(font);
+    });
   });
 
-  return;
+  if (typeof callback === 'function') {
+    return openingPromise.then(font => callback(null, font)).catch(err => callback(err));
+  }
+
+  return openingPromise;
 };
 
 fontkit.create = function(buffer, postscriptName) {

--- a/test/index.js
+++ b/test/index.js
@@ -2,12 +2,24 @@ import fontkit from '../src';
 import assert from 'assert';
 
 describe('fontkit', function() {
-  it('should open a font asynchronously', () =>
+  it('should open a font asynchronously with callback', () =>
     fontkit.open(__dirname + '/data/OpenSans/OpenSans-Regular.ttf', function(err, font) {
       assert.equal(err, null);
       return assert.equal(font.constructor.name, 'TTFFont');
     })
   );
+
+  it('should open a font asynchronously without callback, returning a Promise', async () => {
+    let err = null;
+    let font;
+    try {
+      font = await fontkit.open(__dirname + '/data/OpenSans/OpenSans-Regular.ttf');
+    } catch (e) {
+      err = e;
+    }
+    assert.equal(err, null);
+    return assert.equal(font.constructor.name, 'TTFFont');
+  });
 
   it('should open a font synchronously', function() {
     let font = fontkit.openSync(__dirname + '/data/OpenSans/OpenSans-Regular.ttf');


### PR DESCRIPTION
This will help to make react-pdf asynchronous using `async..await` when running server-side.